### PR TITLE
fix(FEV-1591): screen reader doesn't read content inside info overlay

### DIFF
--- a/src/components/info/index.tsx
+++ b/src/components/info/index.tsx
@@ -31,7 +31,7 @@ export class Info extends Component<MergedProps> {
     }
     return (
       <Overlay open onClose={onClick}>
-        <div className={[styles.infoRoot, styles[playerSize]].join(' ')}>
+        <div className={[styles.infoRoot, styles[playerSize]].join(' ')} aria-live={'polite'}>
           {broadcastedDate && <div className={styles.broadcastDate}>{broadcastedDate}</div>}
           <div className={styles.entryName}>{entryName}</div>
           {description && <div className={styles.entryDescription} dangerouslySetInnerHTML={{__html: sanitizeHtml(description)}} />}


### PR DESCRIPTION
**the issue:**
when clicking on info plugin button and screen reader is on, it doesn't read the content (title, description, etc.).

**solution:**
add `aria-live='polite'` to the root element.

Solves [FEV-1591](https://kaltura.atlassian.net/browse/FEV-1591)