### PR TITLE
fix(FEV-1591): screen reader doesn't read content inside info overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "html5 player"
   ],
   "dependencies": {
-    "@playkit-js/common": "^1.0.7",
+    "@playkit-js/common": "^1.0.11",
     "@playkit-js/ui-managers": "^1.3.0",
     "sanitize-html": "^2.7.1"
   },

--- a/src/components/info/index.tsx
+++ b/src/components/info/index.tsx
@@ -1,6 +1,7 @@
 import {h, Component} from 'preact';
 import * as styles from './info.scss';
 import * as sanitizeHtml from 'sanitize-html';
+import { OverlayPortal } from '@playkit-js/common';
 const {
   components: {PLAYER_SIZE},
   redux: {connect}
@@ -30,13 +31,16 @@ export class Info extends Component<MergedProps> {
       return null;
     }
     return (
-      <Overlay open onClose={onClick}>
-        <div className={[styles.infoRoot, styles[playerSize]].join(' ')} aria-live={'polite'}>
-          {broadcastedDate && <div className={styles.broadcastDate}>{broadcastedDate}</div>}
-          <div className={styles.entryName}>{entryName}</div>
-          {description && <div className={styles.entryDescription} dangerouslySetInnerHTML={{__html: sanitizeHtml(description)}} />}
-        </div>
-      </Overlay>
+        <OverlayPortal>
+            <Overlay open onClose={onClick}>
+                <div className={[styles.infoRoot, styles[playerSize]].join(' ')}>
+                  {broadcastedDate && <div className={styles.broadcastDate}>{broadcastedDate}</div>}
+                  <div className={styles.entryName}>{entryName}</div>
+                  {description && <div className={styles.entryDescription}
+                                       dangerouslySetInnerHTML={{__html: sanitizeHtml(description)}}/>}
+                </div>
+            </Overlay>
+        </OverlayPortal>
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -628,10 +628,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@playkit-js/common@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.0.7.tgz#ef4505c08584fde300638892add98f856691d778"
-  integrity sha512-6rr+k5c6y7aITG1NRH3PnYSm1l20Id905NMp8XQbA4DmJk0r4AX5sz9YfH9NSGDQx3UKYGkLLYSEbwFYlfFu+g==
+"@playkit-js/common@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@playkit-js/common/-/common-1.0.11.tgz#f155283dbd2cdc7f2560eb0a9c18b55d10bbe518"
+  integrity sha512-3R0gnQ/cdeamZ1PHC2nKvKbIC07OMuMKw39YN4SyGdcleDzxYKQq+2yK7D09JiR9GHcENsQa9s5Jr8JqXDcDmQ==
   dependencies:
     linkify-it "^4.0.1"
 


### PR DESCRIPTION
**the issue:**
when clicking on info plugin button and screen reader is on, it doesn't read the content (title, description, etc.).

**solution:**
use OverlayPortal comp from common repo, to wrap the Overlay component in info plugin. this will inject overlay & children directly to overlay-portal element.

Solves [FEV-1591](https://kaltura.atlassian.net/browse/FEV-1591)