### PR TITLE
fix(FEC-13517): Wrong and inconsistent order of plugins & Plugins buttons sometimes display with the wrong icon

### DIFF
--- a/src/components/plugin-button/index.tsx
+++ b/src/components/plugin-button/index.tsx
@@ -1,6 +1,7 @@
 import {h} from 'preact';
 import {icons} from '../icons';
 import {ui} from '@playkit-js/kaltura-player-js';
+import { pluginName } from "../../index";
 
 const {Tooltip, Icon} = KalturaPlayer.ui.components;
 const {Text} = ui.preacti18n;
@@ -15,7 +16,7 @@ export const PluginButton = ({label, setRef}: PluginButtonProps) => {
     <Tooltip label={infoTxt} type="bottom">
         <button type="button" aria-label={label} className={ui.style.upperBarIcon} data-testid="infoPluginButton" ref={setRef}>
           <Icon
-            id="info-plugin-button"
+            id={pluginName}
             height={icons.BigSize}
             width={icons.BigSize}
             viewBox={`0 0 ${icons.BigSize} ${icons.BigSize}`}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,5 @@ const NAME = __NAME__;
 export {PlaykitJsInfoPlugin as Plugin};
 export {VERSION, NAME};
 
-const pluginName: string = 'playkit-js-info';
+export const pluginName: string = 'playkit-js-info';
 KalturaPlayer.core.registerPlugin(pluginName, PlaykitJsInfoPlugin);

--- a/src/info-plugin.tsx
+++ b/src/info-plugin.tsx
@@ -150,6 +150,7 @@ export class PlaykitJsInfoPlugin extends KalturaPlayer.core.BasePlugin {
         // @ts-ignore
         ariaLabel: <Text id="info.info">Info</Text>,
         displayName: 'Info',
+        order: 80,
         component: () => <PluginButton label="Video info" setRef={this._setPluginButtonRef}/>,
         svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},
         onClick: this._openInfo

--- a/src/info-plugin.tsx
+++ b/src/info-plugin.tsx
@@ -143,9 +143,13 @@ export class PlaykitJsInfoPlugin extends KalturaPlayer.core.BasePlugin {
       return;
     }
     this.player.ready().then(() => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       this._iconId = this.upperBarManager!.add({
-        //@ts-ignore
-        label: <Text id="info.info">Info</Text>,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        ariaLabel: <Text id="info.info">Info</Text>,
+        displayName: 'Info',
         component: () => <PluginButton label="Video info" setRef={this._setPluginButtonRef}/>,
         svgIcon: {path: icons.PLUGIN_ICON, viewBox: `0 0 ${icons.BigSize} ${icons.BigSize}`},
         onClick: this._openInfo


### PR DESCRIPTION
### Description of the Changes


**fix: Wrong and inconsistent order of plugins**

**fix: Plugins buttons sometimes display with the wrong icon**

**solves: [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517) [FEC-13517](https://kaltura.atlassian.net/browse/FEC-13517)**

[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FEC-13517]: https://kaltura.atlassian.net/browse/FEC-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

#### Related Prs
https://github.com/kaltura/playkit-js-ui-managers/pull/51
https://github.com/kaltura/playkit-js-transcript/pull/175
https://github.com/kaltura/playkit-js-share/pull/38
https://github.com/kaltura/playkit-js-moderation/pull/74
https://github.com/kaltura/playkit-js-playlist/pull/53
https://github.com/kaltura/playkit-js-related/pull/61
https://github.com/kaltura/playkit-js-navigation/pull/348
https://github.com/kaltura/playkit-js-downloads/pull/39
https://github.com/kaltura/playkit-js-qna/pull/334