### PR TITLE
fix(ADA-490): [V7-Acc] SVG icons need to be hidden from screen reader update

### DIFF
--- a/src/components/plugin-button/index.tsx
+++ b/src/components/plugin-button/index.tsx
@@ -21,6 +21,7 @@ export const PluginButton = ({label, setRef}: PluginButtonProps) => {
             width={icons.BigSize}
             viewBox={`0 0 ${icons.BigSize} ${icons.BigSize}`}
             path={icons.PLUGIN_ICON}
+            hidden="true"
           />
         </button>
     </Tooltip>


### PR DESCRIPTION
Adding "aria-hidden" to the info icon

Resolves [ADA-490](https://kaltura.atlassian.net/browse/ADA-490)

[ADA-490]: https://kaltura.atlassian.net/browse/ADA-490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ