### PR TITLE
fix(ADA-1734): Continues ADA-1500, Added Localizer

### DIFF
--- a/src/info-plugin.tsx
+++ b/src/info-plugin.tsx
@@ -7,7 +7,7 @@ import {OnClickEvent} from '@playkit-js/common/dist/hoc/a11y-wrapper';
 import {UpperBarManager} from '@playkit-js/ui-managers';
 import {InfoEvent} from './event';
 const {ReservedPresetNames} = ui;
-const {Text} = ui.preacti18n;
+const {Text, Localizer} = ui.preacti18n;
 
 // @ts-ignore
 export class PlaykitJsInfoPlugin extends KalturaPlayer.core.BasePlugin {
@@ -146,7 +146,14 @@ export class PlaykitJsInfoPlugin extends KalturaPlayer.core.BasePlugin {
       this._iconId = this.upperBarManager!.add({
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        ariaLabel: <Text id="info.info">Info</Text>,
+        ariaLabel: () => {
+          const textJSX = (
+            <Localizer>
+              <Text id="info.info">Info</Text>
+            </Localizer>
+          );
+          return textJSX
+        },
         displayName: 'Info',
         order: 80,
         component: () => <PluginButton label="Video info" setRef={this._setPluginButtonRef}/> as any,


### PR DESCRIPTION
**With:**
- Other Plugins involved:
https://github.com/kaltura/playkit-js-share/pull/54
https://github.com/kaltura/playkit-js-downloads/pull/73
https://github.com/kaltura/playkit-js-moderation/pull/95

- For JSX conversion is required this PR that adds "preact-render-to-string" library:

**Issue:**:
Previous JSX was not translated when loaded in the ui-managers
This was causing aria-label to be rendered: [Object object]

**Fix**:
For translation added Localizer component as well