### PR TITLE
fix(ADA-1745) - Include modal title into close button aria-label 

### DIFF
--- a/src/components/info/index.tsx
+++ b/src/components/info/index.tsx
@@ -101,7 +101,7 @@ export class Info extends Component<MergedProps> {
     }
     return (
       <OverlayPortal>
-        <Overlay open onClose={onClick} addAccessibleChild={addAccessibleChild} handleKeyDown={handleKeyDown}>
+        <Overlay open onClose={onClick} closeAriaLabel="Close Video Info" addAccessibleChild={addAccessibleChild} handleKeyDown={handleKeyDown}>
           <div className={[styles.infoRoot, styles[playerSize]].join(' ')} data-testid="infoRoot">
             <div className={styles.entryName} data-testid="entryName">
               <h2>{entryName}</h2>

--- a/src/components/info/index.tsx
+++ b/src/components/info/index.tsx
@@ -99,9 +99,10 @@ export class Info extends Component<MergedProps> {
     if (playerSize === PLAYER_SIZE.TINY) {
       return null;
     }
+    const closeTxt =  <Text id="controls.close">Close Video Info</Text>;
     return (
       <OverlayPortal>
-        <Overlay open onClose={onClick} closeAriaLabel="Close Video Info" addAccessibleChild={addAccessibleChild} handleKeyDown={handleKeyDown}>
+        <Overlay open onClose={onClick} closeAriaLabel={closeTxt} addAccessibleChild={addAccessibleChild} handleKeyDown={handleKeyDown}>
           <div className={[styles.infoRoot, styles[playerSize]].join(' ')} data-testid="infoRoot">
             <div className={styles.entryName} data-testid="entryName">
               <h2>{entryName}</h2>

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -1,7 +1,8 @@
 {
   "en": {
     "controls": {
-      "info": "Video info"
+      "info": "Video info",
+      "close": "Close Video Info"
     },
     "info": {
       "info": "Info",


### PR DESCRIPTION
This solves https://kaltura.atlassian.net/browse/ADA-1745
Related to  https://github.com/kaltura/playkit-js-ui/pull/984 and https://github.com/kaltura/playkit-js-downloads/pull/84