### PR TITLE
fix(ADA-1736) - Tooltip strict position

### DIFF
--- a/src/components/plugin-button/index.tsx
+++ b/src/components/plugin-button/index.tsx
@@ -13,7 +13,7 @@ interface PluginButtonProps {
 export const PluginButton = ({label, setRef}: PluginButtonProps) => {
     const infoTxt =  <Text id="controls.info">Video info</Text>;
     return (
-    <Tooltip label={infoTxt} type="bottom">
+    <Tooltip label={infoTxt} type="bottom-left" strictPosition={true}>
         <button type="button" aria-label={label} className={ui.style.upperBarIcon} data-testid="infoPluginButton" ref={setRef}>
           <Icon
             id={pluginName}


### PR DESCRIPTION
This solves https://kaltura.atlassian.net/browse/ADA-1736.
It sets the Tooltip position to always be bottom-left.